### PR TITLE
플레이어1, 플레이어2 프리펩 수정

### DIFF
--- a/Assets/Animations/Player2.controller
+++ b/Assets/Animations/Player2.controller
@@ -55,7 +55,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: PushGlovePlayer2
+  m_Name: PushGlove
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:

--- a/Assets/InputTest/InputPlayer.cs
+++ b/Assets/InputTest/InputPlayer.cs
@@ -8,12 +8,12 @@ public class InputPlayer : MonoBehaviour
     [SerializeField] private ExChargeUi UI;
     [SerializeField] private SoundManager soundManager;
 
-    public PlayerInput playerInput;
-    public Transform grabObject;
+    public PlayerInput PlayerInput;
+    public Transform GrabObject;
     public PushGlove PushGlove;
     public Grab GrabGlove;
-    public Animator anim;
-    public List<AudioClip> player1Sounds = new List<AudioClip>();
+    public Animator Anim;
+    public List<AudioClip> PlayerSounds = new List<AudioClip>();
 
     private Rigidbody2D rb;
     Vector2 moveInput;
@@ -49,14 +49,14 @@ public class InputPlayer : MonoBehaviour
     void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
-        if (playerInput == null) playerInput = GetComponent<PlayerInput>();
-        if (anim == null && transform.parent != null) anim = transform.parent.GetComponent<Animator>();
+        if (PlayerInput == null) PlayerInput = GetComponent<PlayerInput>();
+        if (Anim == null && transform.parent != null) Anim = transform.parent.GetComponent<Animator>();
     }
 
     void OnEnable()
     {
-        if (playerInput != null)
-            ControlScheme = playerInput.currentControlScheme;
+        if (PlayerInput != null)
+            ControlScheme = PlayerInput.currentControlScheme;
     }
 
     void Update()
@@ -70,7 +70,7 @@ public class InputPlayer : MonoBehaviour
         if (GrabHeld) UI.OnGrab();
         else UI.OffGrab();
 
-        if (playerInput != null) ControlScheme = playerInput.currentControlScheme;
+        if (PlayerInput != null) ControlScheme = PlayerInput.currentControlScheme;
 
         if (isCharging)
         {
@@ -88,8 +88,8 @@ public class InputPlayer : MonoBehaviour
 
         if (jumpAble)
         {
-            if (Mathf.Abs(moveInput.x) > 0.01f) anim?.Play("Move");
-            else anim?.Play("Idle");
+            if (Mathf.Abs(moveInput.x) > 0.01f) Anim?.Play("Move");
+            else Anim?.Play("Idle");
         }
     }
 
@@ -135,8 +135,8 @@ public class InputPlayer : MonoBehaviour
         {
             rb.AddForce(Vector2.up * 15f, ForceMode2D.Impulse);
             jumpAble = false;
-            SoundManager.Instance?.SFXPlay("PlayerJump_1", player1Sounds[(int)PlayerSounds.Jump]);
-            anim?.Play("Jump");
+            SoundManager.Instance?.SFXPlay("PlayerJump_1", PlayerSounds[(int)global::PlayerSounds.Jump]);
+            Anim?.Play("Jump");
         }
     }
 
@@ -155,7 +155,7 @@ public class InputPlayer : MonoBehaviour
             {
                 isCharging = false;
                 Push = true;
-                SoundManager.Instance?.SFXPlay("PlayerPush_1", player1Sounds[(int)PlayerSounds.Push]);
+                SoundManager.Instance?.SFXPlay("PlayerPush_1", PlayerSounds[(int)global::PlayerSounds.Push]);
             }
         }
     }
@@ -167,7 +167,7 @@ public class InputPlayer : MonoBehaviour
             GrabHeld = true;
             isGrabHolding = true;
             RPressTime = Time.time;
-            if (grabObject != null) grabObject.rotation = Quaternion.Euler(0f, 0f, 0f);
+            if (GrabObject != null) GrabObject.rotation = Quaternion.Euler(0f, 0f, 0f);
         }
         else if (context.canceled)
         {
@@ -175,7 +175,7 @@ public class InputPlayer : MonoBehaviour
             isGrabHolding = false;
 
             GrabGlove.DOGrab();
-            SoundManager.Instance?.SFXPlay("PlayerPull_1", player1Sounds[(int)PlayerSounds.Pull]);
+            SoundManager.Instance?.SFXPlay("PlayerPull_1", PlayerSounds[(int)global::PlayerSounds.Pull]);
             grabControlInput = Vector2.zero;
         }
     }
@@ -187,7 +187,7 @@ public class InputPlayer : MonoBehaviour
 
     private void UpdateGrabRotation()
     {
-        if (grabObject == null) return;
+        if (GrabObject == null) return;
         if (!isGrabHolding) return;
 
         bool isKeyboard = ControlScheme != null && ControlScheme.ToLower().Contains("keyboard");
@@ -200,18 +200,18 @@ public class InputPlayer : MonoBehaviour
             {
                 Vector2 screenPos = mouse.position.ReadValue();
                 Vector3 world = cam.ScreenToWorldPoint(new Vector3(screenPos.x, screenPos.y, cam.nearClipPlane));
-                world.z = grabObject.position.z;
+                world.z = GrabObject.position.z;
 
-                Vector3 dirWorld = world - grabObject.position;
+                Vector3 dirWorld = world - GrabObject.position;
                 Vector3 dirLocal = transform.InverseTransformDirection(dirWorld);
 
                 if (dirLocal.sqrMagnitude > 0.0001f)
                 {
                     float rawLocalAngle = Mathf.Atan2(dirLocal.y, dirLocal.x) * Mathf.Rad2Deg;
                     float desiredLocal = Mathf.Clamp(rawLocalAngle, -Mathf.Abs(maxAngle), Mathf.Abs(maxAngle));
-                    float currentLocalZ = grabObject.localEulerAngles.z;
+                    float currentLocalZ = GrabObject.localEulerAngles.z;
                     float smoothLocalZ = Mathf.LerpAngle(currentLocalZ, desiredLocal, Time.deltaTime * aimSmooth);
-                    grabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
+                    GrabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
                 }
                 else
                 {
@@ -230,9 +230,9 @@ public class InputPlayer : MonoBehaviour
             {
                 float rawAngle = Mathf.Atan2(stick.y, stick.x) * Mathf.Rad2Deg;
                 float desiredLocal = Mathf.Clamp(rawAngle, -Mathf.Abs(maxAngle), Mathf.Abs(maxAngle));
-                float currentLocalZ = grabObject.localEulerAngles.z;
+                float currentLocalZ = GrabObject.localEulerAngles.z;
                 float smoothLocalZ = Mathf.LerpAngle(currentLocalZ, desiredLocal, Time.deltaTime * aimSmooth);
-                grabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
+                GrabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
             }
             else
             {
@@ -243,21 +243,21 @@ public class InputPlayer : MonoBehaviour
 
     private void ApplyOscillationIfNeeded()
     {
-        if (grabObject == null) return;
+        if (GrabObject == null) return;
 
         if (Time.time - RPressTime >= 0.5f)
         {
             float elapsed = Time.time - RPressTime - 0.5f;
             float angle = Mathf.Sin(elapsed * RotSpeed) * maxAngle;
-            float currentLocalZ = grabObject.localEulerAngles.z;
+            float currentLocalZ = GrabObject.localEulerAngles.z;
             float smoothLocalZ = Mathf.LerpAngle(currentLocalZ, angle, Time.deltaTime * aimSmooth);
-            grabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
+            GrabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
         }
         else
         {
-            float currentLocalZ = grabObject.localEulerAngles.z;
+            float currentLocalZ = GrabObject.localEulerAngles.z;
             float smoothLocalZ = Mathf.LerpAngle(currentLocalZ, 0f, Time.deltaTime * aimSmooth);
-            grabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
+            GrabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);
         }
     }
 
@@ -291,14 +291,14 @@ public class InputPlayer : MonoBehaviour
 
     public void Die()
     {
-        SoundManager.Instance.SFXPlay("PlayerDied_1", player1Sounds[(int)PlayerSounds.Die]);
-        anim.Play("Die");
+        SoundManager.Instance.SFXPlay("PlayerDied_1", PlayerSounds[(int)global::PlayerSounds.Die]);
+        Anim.Play("Die");
         cantMove = true;
     }
 
     public void Cleared()
     {
         cantMove = true;
-        anim.Play("Cleared");
+        Anim.Play("Cleared");
     }
 }

--- a/Assets/InputTest/InputTestScene.unity
+++ b/Assets/InputTest/InputTestScene.unity
@@ -709,14 +709,16 @@ PrefabInstance:
       propertyPath: m_Name
       value: NewPlayer1Anim
       objectReference: {fileID: 0}
+    - target: {fileID: 7256012623865335736, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8040103551830744619, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
       propertyPath: m_Name
       value: Grab
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 7476478576660501425, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
-    - {fileID: 3831218754039041819, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
-    - {fileID: 32476761096139467, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -726,6 +728,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 383496396358986526, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
       insertIndex: -1
       addedObject: {fileID: 197891713}
+    - targetCorrespondingSourceObject: {fileID: 383496396358986526, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 197891727}
     - targetCorrespondingSourceObject: {fileID: 1538751184656066701, guid: da54ca5b60202144da447369c8a81f2c, type: 3}
       insertIndex: -1
       addedObject: {fileID: 37074229}
@@ -1044,12 +1049,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UI: {fileID: 778982703}
   soundManager: {fileID: 277082298}
-  playerInput: {fileID: 197891713}
-  grabObject: {fileID: 910237593}
+  PlayerInput: {fileID: 197891713}
+  GrabObject: {fileID: 910237593}
   PushGlove: {fileID: 37074229}
   GrabGlove: {fileID: 1963683220}
-  anim: {fileID: 1421485688}
-  player1Sounds:
+  Anim: {fileID: 1421485688}
+  PlayerSounds:
   - {fileID: 8300000, guid: 2c5292ba5cf254919a6b9e2b18e04f49, type: 3}
   - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
   - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
@@ -1066,6 +1071,21 @@ MonoBehaviour:
   RotSpeed: 1
   maxAngle: 20
   grabDeadzone: 0.15
+  ControlScheme: Keyboard, Mouse
+--- !u!114 &197891727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197891710}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e154110ee543fb478491d35570f1452, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  playanim: 0
 --- !u!1 &277082297
 GameObject:
   m_ObjectHideFlags: 0
@@ -1873,6 +1893,30 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &502286095 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 841676087012901352, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+  m_PrefabInstance: {fileID: 1929919255}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &502286102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 502286095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d82f67861abd1243aba1e86bb848988, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Target: {fileID: 0}
+  addtargetPos: {x: 19, y: 0, z: 0}
+  moveSpeed: 0
+  holdGrab: 0
+  grabing: 0
+  targetingable: 0
+  GrabPlayer: 0
 --- !u!1 &538754376
 GameObject:
   m_ObjectHideFlags: 0
@@ -3623,6 +3667,25 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cf46c035fe44bfc46a168783dabaa785, type: 3}
+--- !u!1 &1105635311 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8454353221532442318, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+  m_PrefabInstance: {fileID: 1929919255}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1105635316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1105635311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65c4c6fe69fcd174bab1f20bd5119e38, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _PushPower: 0
+  _canPush: 1
 --- !u!1 &1125612489
 GameObject:
   m_ObjectHideFlags: 0
@@ -4949,6 +5012,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 203ca478c2f9d3640895252169ff28a7, type: 3}
+--- !u!95 &1923942295 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 530598904557741320, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+  m_PrefabInstance: {fileID: 1929919255}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1929919255
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4967,7 +5035,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6539536214699927520, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7206212823979965839, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4977,6 +5045,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: 4.1
       objectReference: {fileID: 0}
+    - target: {fileID: 8045046126432506304, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      propertyPath: Player
+      value: 
+      objectReference: {fileID: 2034766572}
     - target: {fileID: 8104391497698397831, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
       propertyPath: m_LocalPosition.x
       value: 26.18
@@ -5017,10 +5089,33 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2369459865458287543, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+    - {fileID: 696728593566531801, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+    - {fileID: 6066187000064921542, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+    - {fileID: 2118999950145397885, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+    - {fileID: 7385952680103018084, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5477906228450719680, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2034766573}
+    - targetCorrespondingSourceObject: {fileID: 5477906228450719680, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2034766572}
+    - targetCorrespondingSourceObject: {fileID: 5477906228450719680, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2034766571}
+    - targetCorrespondingSourceObject: {fileID: 5477906228450719680, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2034766570}
+    - targetCorrespondingSourceObject: {fileID: 8454353221532442318, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1105635316}
+    - targetCorrespondingSourceObject: {fileID: 841676087012901352, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 502286102}
   m_SourcePrefab: {fileID: 100100000, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
 --- !u!1 &1963683213 stripped
 GameObject:
@@ -5046,6 +5141,211 @@ MonoBehaviour:
   grabing: 0
   targetingable: 0
   GrabPlayer: 0
+--- !u!114 &2026914646 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8045046126432506304, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+  m_PrefabInstance: {fileID: 1929919255}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6444dce363c08954c9a2875e07136153, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2034766561 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5477906228450719680, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+  m_PrefabInstance: {fileID: 1929919255}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2034766570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034766561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e154110ee543fb478491d35570f1452, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  playanim: 0
+--- !u!114 &2034766571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034766561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 557217b922235ff4ebadcedaa16d612e, type: 3}
+  m_NotificationBehavior: 2
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2034766572}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnJump
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 5b2dd577-91f9-41de-958e-aa906db0f20c
+    m_ActionName: Player Action/Jump[/Keyboard/w]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 19149502-4e56-4fde-a76f-b7658902ccf1
+    m_ActionName: Player Action/UIControll[/Keyboard/downArrow,/Keyboard/upArrow,/Keyboard/leftArrow,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: defeb76e-259c-4c1b-afb2-c91e142a7095
+    m_ActionName: Player Action/UISellect[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2034766572}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnGrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 420fff61-9cde-4dfb-a263-af02ab7fe3c9
+    m_ActionName: Player Action/Grab[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 3022fc1f-d450-4194-a219-71aff382fdbf
+    m_ActionName: Player Action/GrabControll[/Mouse/position]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2034766572}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnPush
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: a7b9536a-bf4c-46c4-8beb-047cc7cb4efe
+    m_ActionName: Player Action/Push[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 8a1cd7d1-3261-422b-8fb4-7b392399c4ac
+    m_ActionName: Player Action/Menu[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2034766572}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnMoveRight
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: b5511281-a936-42c9-b3c1-32103082505a
+    m_ActionName: Player Action/MoveRight[/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2034766572}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnMoveLeft
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: e3fb9b2b-ff34-43cd-b368-e61a2b3fb6f7
+    m_ActionName: Player Action/MoveLeft[/Keyboard/a]
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: Keyboard, Mouse
+  m_DefaultActionMap: Player Action
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &2034766572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034766561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85b5065e3e1f7fb418f4b19c1b8f517a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UI: {fileID: 2026914646}
+  soundManager: {fileID: 277082298}
+  PlayerInput: {fileID: 2034766571}
+  GrabObject: {fileID: 2071815784}
+  PushGlove: {fileID: 1105635316}
+  GrabGlove: {fileID: 502286102}
+  Anim: {fileID: 1923942295}
+  PlayerSounds:
+  - {fileID: 8300000, guid: 2c5292ba5cf254919a6b9e2b18e04f49, type: 3}
+  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
+  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
+  - {fileID: 8300000, guid: 5039414d94a6e4e70a5ab9e8833e992a, type: 3}
+  moveSpeed: 4
+  flip: 0
+  flipThreshold: 0.2
+  cantMove: 0
+  jumpAble: 1
+  MaxPushCharge: 35
+  ChargeTime: 1
+  PushCharge: 0
+  Push: 0
+  RotSpeed: 1
+  maxAngle: 20
+  grabDeadzone: 0.15
+  ControlScheme: Keyboard, Mouse
+--- !u!114 &2034766573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034766561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e5b30423f6e16d43bd9b9e3ae5e000e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2071023357
 GameObject:
   m_ObjectHideFlags: 0
@@ -5095,6 +5395,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2071815784 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 199681723346479633, guid: 3e0ae6b3a2f6d124a950683c0b25bae4, type: 3}
+  m_PrefabInstance: {fileID: 1929919255}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/InputTest/PlayerAnim.cs
+++ b/Assets/InputTest/PlayerAnim.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerAnim : MonoBehaviour
+{
+    Animator anim;
+    [SerializeField] private InputPlayer player;
+
+    [SerializeField] public bool playanim;
+
+    private void Awake()
+    {
+        player = GetComponent<InputPlayer>();
+        anim = GetComponent<Animator>();
+    }
+
+    private void Update()
+    {
+        AnimatorStateInfo stateinfo = anim.GetCurrentAnimatorStateInfo(0);
+
+        if (player.Push && !playanim)
+        {
+            anim.Play("PushGlove");
+            playanim = true;
+        }
+
+        if (stateinfo.IsName("PushGlove") && stateinfo.normalizedTime > 0.8f)
+        {
+            player.Push = false;
+            playanim = false;
+        }
+    }
+}

--- a/Assets/InputTest/PlayerAnim.cs
+++ b/Assets/InputTest/PlayerAnim.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class PlayerAnim : MonoBehaviour
 {
     Animator anim;
-    [SerializeField] private InputPlayer player;
+    private InputPlayer player;
 
     [SerializeField] private bool playanim;
 

--- a/Assets/InputTest/PlayerAnim.cs
+++ b/Assets/InputTest/PlayerAnim.cs
@@ -7,7 +7,7 @@ public class PlayerAnim : MonoBehaviour
     Animator anim;
     [SerializeField] private InputPlayer player;
 
-    [SerializeField] public bool playanim;
+    [SerializeField] private bool playanim;
 
     private void Awake()
     {

--- a/Assets/InputTest/PlayerAnim.cs.meta
+++ b/Assets/InputTest/PlayerAnim.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e154110ee543fb478491d35570f1452
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/InputTest/RebindingManager.cs
+++ b/Assets/InputTest/RebindingManager.cs
@@ -12,7 +12,6 @@ public class RebindingManager : MonoBehaviour
 
     private readonly HashSet<string> _lockedActions = new HashSet<string>
     {
-        "Move",
         "Menu",
         "GrabControll",
         "UIControll"

--- a/Assets/Prefabs/NewPlayer1Anim.prefab
+++ b/Assets/Prefabs/NewPlayer1Anim.prefab
@@ -80,9 +80,10 @@ GameObject:
   - component: {fileID: 5369297074842519046}
   - component: {fileID: 422501465563376348}
   - component: {fileID: 9020937538045288243}
-  - component: {fileID: 3831218754039041819}
-  - component: {fileID: 32476761096139467}
   - component: {fileID: 6672557325228413975}
+  - component: {fileID: 9045377144482777068}
+  - component: {fileID: 6212746808201683697}
+  - component: {fileID: 8547310634209535652}
   m_Layer: 0
   m_Name: Player1
   m_TagString: interactive
@@ -100,7 +101,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.09, y: 3.44, z: -0.07203}
-  m_LocalScale: {x: -1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6499941440800051760}
@@ -244,46 +245,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &3831218754039041819
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 383496396358986526}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9adaa15af04de2042b0dc6e72ac748b2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveSpeed: 4
-  x: 0
-  jumpAble: 1
-  Push: 0
-  flip: 1
-  pushCharge: 0
-  maxPushCharge: 35
-  chargeTime: 1
-  cantMove: 0
-  RotSpeed: 1
-  maxAngle: 20
-  player1Sounds:
-  - {fileID: 8300000, guid: 2c5292ba5cf254919a6b9e2b18e04f49, type: 3}
-  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
-  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
-  - {fileID: 8300000, guid: 5039414d94a6e4e70a5ab9e8833e992a, type: 3}
---- !u!114 &32476761096139467
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 383496396358986526}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c6b1e1c27e8feb4fb413b5a8905990a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6672557325228413975
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -296,6 +257,195 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e5b30423f6e16d43bd9b9e3ae5e000e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &9045377144482777068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 383496396358986526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85b5065e3e1f7fb418f4b19c1b8f517a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UI: {fileID: 381160461859590650}
+  soundManager: {fileID: 0}
+  PlayerInput: {fileID: 6212746808201683697}
+  GrabObject: {fileID: 7881057433856660155}
+  PushGlove: {fileID: 7977809641205117588}
+  GrabGlove: {fileID: 3639984214711426537}
+  Anim: {fileID: 1796438022125577718}
+  PlayerSounds:
+  - {fileID: 8300000, guid: 2c5292ba5cf254919a6b9e2b18e04f49, type: 3}
+  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
+  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
+  - {fileID: 8300000, guid: 5039414d94a6e4e70a5ab9e8833e992a, type: 3}
+  moveSpeed: 4
+  flip: 0
+  flipThreshold: 0.2
+  cantMove: 0
+  jumpAble: 1
+  MaxPushCharge: 35
+  ChargeTime: 1
+  PushCharge: 0
+  Push: 0
+  RotSpeed: 1
+  maxAngle: 20
+  grabDeadzone: 0.15
+  ControlScheme: Keyboard, Mouse
+--- !u!114 &6212746808201683697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 383496396358986526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 557217b922235ff4ebadcedaa16d612e, type: 3}
+  m_NotificationBehavior: 2
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9045377144482777068}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnJump
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 5b2dd577-91f9-41de-958e-aa906db0f20c
+    m_ActionName: Player Action/Jump[/Keyboard/w]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 19149502-4e56-4fde-a76f-b7658902ccf1
+    m_ActionName: Player Action/UIControll[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: defeb76e-259c-4c1b-afb2-c91e142a7095
+    m_ActionName: Player Action/UISellect[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9045377144482777068}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnGrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 420fff61-9cde-4dfb-a263-af02ab7fe3c9
+    m_ActionName: Player Action/Grab[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9045377144482777068}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnGrabControll
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 3022fc1f-d450-4194-a219-71aff382fdbf
+    m_ActionName: Player Action/GrabControll[/Mouse/position]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9045377144482777068}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnPush
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: a7b9536a-bf4c-46c4-8beb-047cc7cb4efe
+    m_ActionName: Player Action/Push[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 8a1cd7d1-3261-422b-8fb4-7b392399c4ac
+    m_ActionName: Player Action/Menu[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9045377144482777068}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnMoveRight
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: b5511281-a936-42c9-b3c1-32103082505a
+    m_ActionName: Player Action/MoveRight[/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9045377144482777068}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnMoveLeft
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: e3fb9b2b-ff34-43cd-b368-e61a2b3fb6f7
+    m_ActionName: Player Action/MoveLeft[/Keyboard/a]
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: Keyboard, Mouse
+  m_DefaultActionMap: Player Action
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &8547310634209535652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 383496396358986526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e154110ee543fb478491d35570f1452, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  playanim: 0
 --- !u!1 &1342056556455884170
 GameObject:
   m_ObjectHideFlags: 0
@@ -383,7 +533,7 @@ GameObject:
   - component: {fileID: 1617330331224720626}
   - component: {fileID: 5005522851885338144}
   - component: {fileID: 8402557815864820069}
-  - component: {fileID: 7476478576660501425}
+  - component: {fileID: 7977809641205117588}
   m_Layer: 0
   m_Name: PushGlove
   m_TagString: Player1Glove
@@ -493,7 +643,7 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 1, y: 1}
   m_Direction: 0
---- !u!114 &7476478576660501425
+--- !u!114 &7977809641205117588
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -502,13 +652,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 1538751184656066701}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 52f549cbe9625b448b574e3b47b7122f, type: 3}
+  m_Script: {fileID: 11500000, guid: 65c4c6fe69fcd174bab1f20bd5119e38, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _Player1PushPower: 0
-  _Player2PushPower: 0
-  _canPushPlayer1: 1
-  _canPushPlayer2: 1
+  _PushPower: 0
+  _canPush: 1
 --- !u!1 &1708240791715429641
 GameObject:
   m_ObjectHideFlags: 0
@@ -681,8 +829,9 @@ GameObject:
   - component: {fileID: 4599138075380840851}
   - component: {fileID: 1826054566949650107}
   - component: {fileID: 1092455675999686193}
+  - component: {fileID: 3639984214711426537}
   m_Layer: 0
-  m_Name: Player1Grab
+  m_Name: GrabGlove
   m_TagString: Player1Grab
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -907,6 +1056,25 @@ LineRenderer:
   m_UseWorldSpace: 1
   m_Loop: 0
   m_ApplyActiveColorSpace: 1
+--- !u!114 &3639984214711426537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3592784288518633808}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d82f67861abd1243aba1e86bb848988, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Target: {fileID: 0}
+  addtargetPos: {x: 19, y: 0, z: 0}
+  moveSpeed: 0
+  holdGrab: 0
+  grabing: 0
+  targetingable: 0
+  GrabPlayer: 0
 --- !u!1 &4776101192457551186
 GameObject:
   m_ObjectHideFlags: 0
@@ -1348,7 +1516,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7881057433856660155}
   m_Layer: 0
-  m_Name: Grab1
+  m_Name: Grab
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1401,7 +1569,7 @@ RectTransform:
   m_GameObject: {fileID: 8337375384043060266}
   m_LocalRotation: {x: -0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 90}
-  m_LocalScale: {x: -0.01296, y: 0.01296, z: 0.01296}
+  m_LocalScale: {x: 0.01296, y: 0.01296, z: 0.01296}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7605286080421246191}
@@ -1487,7 +1655,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6444dce363c08954c9a2875e07136153, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Player: {fileID: 0}
+  Player: {fileID: 9045377144482777068}
   PChargeGage: {fileID: 6200164008288416873}
   PGage: {fileID: 4175584217774624400}
   PGrabRange: {fileID: 6984113391391192970}

--- a/Assets/Prefabs/NewPlayer2Anim.prefab
+++ b/Assets/Prefabs/NewPlayer2Anim.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 6521442890733610234}
   - component: {fileID: 9118995535521153851}
   - component: {fileID: 6867519119699992807}
-  - component: {fileID: 7385952680103018084}
+  - component: {fileID: 6416290992758479474}
   m_Layer: 0
   m_Name: Player2Grab
   m_TagString: Player2Grab
@@ -240,7 +240,7 @@ LineRenderer:
   m_UseWorldSpace: 1
   m_Loop: 0
   m_ApplyActiveColorSpace: 1
---- !u!114 &7385952680103018084
+--- !u!114 &6416290992758479474
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -249,7 +249,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 841676087012901352}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aceecdc73403a01448741804bb32c633, type: 3}
+  m_Script: {fileID: 11500000, guid: 4d82f67861abd1243aba1e86bb848988, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   Target: {fileID: 0}
@@ -258,6 +258,7 @@ MonoBehaviour:
   holdGrab: 0
   grabing: 0
   targetingable: 0
+  GrabPlayer: 0
 --- !u!1 &1131829641207111788
 GameObject:
   m_ObjectHideFlags: 0
@@ -810,9 +811,10 @@ GameObject:
   - component: {fileID: 4219642175178879016}
   - component: {fileID: 7056042028312160213}
   - component: {fileID: 6519150026009714047}
-  - component: {fileID: 2369459865458287543}
-  - component: {fileID: 696728593566531801}
-  - component: {fileID: 6066187000064921542}
+  - component: {fileID: 412444305621784431}
+  - component: {fileID: 7111912916996499667}
+  - component: {fileID: 6683147627436615884}
+  - component: {fileID: 5523333914444213145}
   m_Layer: 0
   m_Name: Player2
   m_TagString: interactive
@@ -829,7 +831,7 @@ Transform:
   m_GameObject: {fileID: 5477906228450719680}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.67, y: 1.09, z: -0.14750034}
+  m_LocalPosition: {x: -20.7, y: 4.1, z: -0.14750034}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -974,46 +976,7 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &2369459865458287543
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5477906228450719680}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a53e803e6e6fe90448b606061e32d7b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveSpeed: 4
-  x: 0
-  jumpAble: 1
-  Push: 0
-  flip: 0
-  cantMove: 0
-  pushCharge: 0
-  maxPushCharge: 35
-  chargeTime: 1
-  RotSpeed: 1
-  player2Sounds:
-  - {fileID: 8300000, guid: 2c5292ba5cf254919a6b9e2b18e04f49, type: 3}
-  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
-  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
-  - {fileID: 8300000, guid: 5039414d94a6e4e70a5ab9e8833e992a, type: 3}
---- !u!114 &696728593566531801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5477906228450719680}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5a6377504b1090549b09a6e03045381f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6066187000064921542
+--- !u!114 &412444305621784431
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1025,6 +988,183 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e5b30423f6e16d43bd9b9e3ae5e000e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &7111912916996499667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5477906228450719680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85b5065e3e1f7fb418f4b19c1b8f517a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UI: {fileID: 8045046126432506304}
+  soundManager: {fileID: 0}
+  PlayerInput: {fileID: 6683147627436615884}
+  GrabObject: {fileID: 199681723346479633}
+  PushGlove: {fileID: 5491000787423246749}
+  GrabGlove: {fileID: 6416290992758479474}
+  Anim: {fileID: 530598904557741320}
+  PlayerSounds:
+  - {fileID: 8300000, guid: 2c5292ba5cf254919a6b9e2b18e04f49, type: 3}
+  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
+  - {fileID: 8300000, guid: 29bde6326b4c34ad8a12da475f79b50a, type: 3}
+  - {fileID: 8300000, guid: 5039414d94a6e4e70a5ab9e8833e992a, type: 3}
+  moveSpeed: 4
+  flip: 0
+  flipThreshold: 0.2
+  cantMove: 0
+  jumpAble: 1
+  MaxPushCharge: 35
+  ChargeTime: 1
+  PushCharge: 0
+  Push: 0
+  RotSpeed: 1
+  maxAngle: 20
+  grabDeadzone: 0.15
+  ControlScheme: Keyboard, Mouse
+--- !u!114 &6683147627436615884
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5477906228450719680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 557217b922235ff4ebadcedaa16d612e, type: 3}
+  m_NotificationBehavior: 2
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7111912916996499667}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnJump
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 5b2dd577-91f9-41de-958e-aa906db0f20c
+    m_ActionName: Player Action/Jump[/Keyboard/w]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 19149502-4e56-4fde-a76f-b7658902ccf1
+    m_ActionName: Player Action/UIControll[/Keyboard/downArrow,/Keyboard/upArrow,/Keyboard/leftArrow,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: defeb76e-259c-4c1b-afb2-c91e142a7095
+    m_ActionName: Player Action/UISellect[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7111912916996499667}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnGrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 420fff61-9cde-4dfb-a263-af02ab7fe3c9
+    m_ActionName: Player Action/Grab[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 3022fc1f-d450-4194-a219-71aff382fdbf
+    m_ActionName: Player Action/GrabControll[/Mouse/position]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7111912916996499667}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnPush
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: a7b9536a-bf4c-46c4-8beb-047cc7cb4efe
+    m_ActionName: Player Action/Push[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 8a1cd7d1-3261-422b-8fb4-7b392399c4ac
+    m_ActionName: Player Action/Menu[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7111912916996499667}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnMoveRight
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: b5511281-a936-42c9-b3c1-32103082505a
+    m_ActionName: Player Action/MoveRight[/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7111912916996499667}
+        m_TargetAssemblyTypeName: InputPlayer, Assembly-CSharp
+        m_MethodName: OnMoveLeft
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: e3fb9b2b-ff34-43cd-b368-e61a2b3fb6f7
+    m_ActionName: Player Action/MoveLeft[/Keyboard/a]
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: Keyboard, Mouse
+  m_DefaultActionMap: Player Action
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &5523333914444213145
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5477906228450719680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e154110ee543fb478491d35570f1452, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  playanim: 0
 --- !u!1 &6539536214699927520
 GameObject:
   m_ObjectHideFlags: 0
@@ -1194,9 +1334,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6444dce363c08954c9a2875e07136153, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player1: {fileID: 0}
-  player2: {fileID: 2369459865458287543}
-  player: 2
+  Player: {fileID: 7111912916996499667}
   PChargeGage: {fileID: 4300179381880816022}
   PGage: {fileID: 9191910962314589406}
   PGrabRange: {fileID: 3216650249546364919}
@@ -1387,7 +1525,7 @@ GameObject:
   - component: {fileID: 7771050006684909613}
   - component: {fileID: 491579033653556796}
   - component: {fileID: 7351089743488824553}
-  - component: {fileID: 2118999950145397885}
+  - component: {fileID: 5491000787423246749}
   m_Layer: 0
   m_Name: PushGlove
   m_TagString: Player2Glove
@@ -1497,7 +1635,7 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 1, y: 1}
   m_Direction: 0
---- !u!114 &2118999950145397885
+--- !u!114 &5491000787423246749
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1506,10 +1644,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 8454353221532442318}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 52f549cbe9625b448b574e3b47b7122f, type: 3}
+  m_Script: {fileID: 11500000, guid: 65c4c6fe69fcd174bab1f20bd5119e38, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _Player1PushPower: 0
-  _Player2PushPower: 0
-  _canPushPlayer1: 1
-  _canPushPlayer2: 1
+  _PushPower: 0
+  _canPush: 1


### PR DESCRIPTION
수정한 내용을 플레이어 프리펩에 모두 Apply 했습니다.
또한 따로 사용하던 PlayerAnim을 하나의 코드로 합쳤고 애니메이션에서 PushGlove의 이름이 달라 P2의 밀치기 애니메이션이 실행되지 않는 문제를 해결했습니다.