### PR TITLE
그랩 각도조절 문제 해결/ 그랩 중간에 각도조절 가능한 문제 해결

### DIFF
--- a/Assets/InputTest/InputPlayer.cs
+++ b/Assets/InputTest/InputPlayer.cs
@@ -112,7 +112,14 @@ public class InputPlayer : NetworkBehaviour
 
         if (PushGlove != null) PushGlove.PushPower = PushCharge;
 
-        if (GrabGlove != null && !GrabGlove.grabing) UpdateGrabRotation();
+        if (GrabHeld && GrabGlove != null && !GrabGlove.grabing && !isGrabHolding)
+        {
+            isGrabHolding = true;
+            RPressTime = Time.time;
+        }
+
+        if (GrabGlove != null && !GrabGlove.grabing)
+            UpdateGrabRotation();
 
         if (jumpAble)
         {
@@ -338,12 +345,20 @@ public class InputPlayer : NetworkBehaviour
     public void OnGrab(InputAction.CallbackContext context)
     {
         if (!isLocalPlayer) return;
+
         if (context.started)
         {
             GrabHeld = true;
-            isGrabHolding = true;
-            RPressTime = Time.time;
-            if (GrabObject != null) GrabObject.rotation = Quaternion.Euler(0f, 0f, 0f);
+
+            // 그랩이 이미 돌아와 있으면 바로 회전 가능
+            if (GrabGlove != null && !GrabGlove.grabing)
+            {
+                isGrabHolding = true;
+                RPressTime = Time.time;
+
+                if (GrabObject != null)
+                    GrabObject.rotation = Quaternion.Euler(0f, 0f, 0f);
+            }
         }
         else if (context.canceled)
         {

--- a/Assets/InputTest/InputPlayer.cs
+++ b/Assets/InputTest/InputPlayer.cs
@@ -383,12 +383,14 @@ public class InputPlayer : NetworkBehaviour
                 world.z = GrabObject.position.z;
 
                 Vector3 dirWorld = world - GrabObject.position;
-                Vector3 dirLocal = transform.InverseTransformDirection(dirWorld);
 
-                if (dirLocal.sqrMagnitude > 0.0001f)
+                if (dirWorld.sqrMagnitude > 0.0001f)
                 {
-                    float rawLocalAngle = Mathf.Atan2(dirLocal.y, dirLocal.x) * Mathf.Rad2Deg;
-                    float desiredLocal = Mathf.Clamp(rawLocalAngle, -Mathf.Abs(maxAngle), Mathf.Abs(maxAngle));
+                    float facingSign = flip ? -1f : 1f;
+                    float adjustedX = dirWorld.x * facingSign;
+
+                    float desiredLocal = Mathf.Atan2(dirWorld.y, adjustedX) * Mathf.Rad2Deg;
+                    desiredLocal = Mathf.Clamp(desiredLocal, -Mathf.Abs(maxAngle), Mathf.Abs(maxAngle));
                     float currentLocalZ = GrabObject.localEulerAngles.z;
                     float smoothLocalZ = Mathf.LerpAngle(currentLocalZ, desiredLocal, Time.deltaTime * aimSmooth);
                     GrabObject.localRotation = Quaternion.Euler(0f, 0f, smoothLocalZ);


### PR DESCRIPTION
플레이어 방향에 따른 그랩 각도조절의 최댓값 최소값 조정이 오른쪽에서만 정상적으로 작동하던 문제를 해결하였습니다.
그랩 발동중 키를 다시 입력하면 정면 방향으로 각도가 수정되는 문제를 해결하였습니다.